### PR TITLE
Add embeddings method to Engine class

### DIFF
--- a/openai/api_resources/engine.py
+++ b/openai/api_resources/engine.py
@@ -30,3 +30,6 @@ class Engine(ListableAPIResource, UpdateableAPIResource):
 
     def search(self, **params):
         return self.request("post", self.instance_url() + "/search", params)
+
+    def embeddings(self, **params):
+        return self.request("post", self.instance_url() + "/embeddings", params)


### PR DESCRIPTION
This Pull Request adds a new method called 'embeddings' to the 'Engine' class in the 'openai/api_resources/engine.py' file. The 'embeddings' method takes 'params' as input and returns the embeddings from the OpenAI API. This change is made to implement the requested feature as described in issue #123. The 'embeddings' method uses the 'request' method provided by the 'Engine' class to make a POST request to the '/embeddings' endpoint with the provided 'params'. This change should not have any significant impacts on the existing functionality of the 'Engine' class, but it is recommended to review the implementation to ensure it aligns with the OpenAI API specifications. This change addresses the related issue by providing the requested 'embeddings' method functionality.

This PR fixes #1